### PR TITLE
More comprehensive url escaping

### DIFF
--- a/lib/smugmug/http.rb
+++ b/lib/smugmug/http.rb
@@ -1,4 +1,3 @@
-require "cgi"
 require "openssl"
 require "base64"
 require "net/http"
@@ -152,10 +151,10 @@ module SmugMug
       postdata = sorted_args.join("&")
 
       # Final string to hash
-      sig_base = "#{method}&#{CGI::escape("#{uri.scheme}://#{uri.host}#{uri.path}")}&#{CGI::escape(postdata)}"
+      sig_base = "#{method}&#{URI::escape("#{uri.scheme}://#{uri.host}#{uri.path}", uri_escape_regex)}&#{URI::escape(postdata, uri_escape_regex)}"
 
       signature = OpenSSL::HMAC.digest(@digest, "#{@config[:oauth_secret]}&#{@config[:user][:secret]}", sig_base)
-      signature = CGI::escape(Base64.encode64(signature).chomp)
+      signature = URI::escape(Base64.encode64(signature).chomp, uri_escape_regex)
 
       if uri == API_URI
         "#{postdata}&oauth_signature=#{signature}"

--- a/spec/smugmug/http_spec.rb
+++ b/spec/smugmug/http_spec.rb
@@ -94,6 +94,6 @@ describe SmugMug::HTTP do
 
     http = SmugMug::HTTP.new(:api_key => "1234-api", :oauth_secret => "4321-secret", :user => {:token => "abcd-token", :secret => "abcd-secret"})
     postdata = http.sign_request("POST", SmugMug::HTTP::API_URI, {"method" => "smugmug.foo.bar", "a" => "Foo & Bar", "b" => 5, "c" => "Foo\nBar"})
-    postdata.should == "a=Foo+%26+Bar&b=5&c=Foo%0ABar&method=smugmug.foo.bar&oauth_consumer_key=1234-api&oauth_nonce=3858f62230ac3c915f300c664312c63f&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1341594000&oauth_token=abcd-token&oauth_version=1.0&oauth_signature=aACF%2BsJgVSyhWkhT%2BHlIwboZPSw%3D"
+    postdata.should == "a=Foo%20%26%20Bar&b=5&c=Foo%0ABar&method=smugmug.foo.bar&oauth_consumer_key=1234-api&oauth_nonce=3858f62230ac3c915f300c664312c63f&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1341594000&oauth_token=abcd-token&oauth_version=1.0&oauth_signature=C8f06Vw2HDBxSFzTlyBztGjoCXw%3D"
   end
 end


### PR DESCRIPTION
I found issues with `GCI::escape` when creating Smugmug albums via the API. I traced it back to albums that had spaces and commas in their name. These albums failed to create and I'd get a `#35 signature error` back from the API. I traced this back to the escaping in the `HTTP` class.  This pull request addresses this issue.

Here's an example:

``` ruby
require 'cgi'
CGI::escape('Hello, World.')
=> "Hello%2C+World."
```

The `+` in the escaped string is not correctly escaped. It should be `%20` as per the spec. `URI::escape` corrects this, but it doesn't escape commas by default:

``` ruby
URI::escape('Hello, World.')
=> "Hello,%20World."
```

In order to fix this, you can pass in the correct regex for `URI::escape` to use, which is what I've done on this PR.

``` ruby
URI::escape('Hello, World.', Regexp.new("[^#{URI::REGEXP::PATTERN::UNRESERVED}]", false, 'N'))
=> "Hello%2C%20World."
```
