### PR TITLE
Upgrading json dependency to 1.8.2 (RoR 4.2.0)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ruby-smugmug (0.0.1)
-      json (~> 1.7.0)
+      json (~> 1.8.2)
 
 GEM
   remote: http://rubygems.org/
@@ -14,7 +14,7 @@ GEM
       thor (>= 0.14.6)
     guard-rspec (0.6.0)
       guard (>= 0.10.0)
-    json (1.7.3)
+    json (1.8.2)
     listen (0.4.7)
       rb-fchange (~> 0.0.5)
       rb-fsevent (~> 0.9.1)

--- a/ruby-smugmug.gemspec
+++ b/ruby-smugmug.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ruby-smugmug"
 
-  s.add_dependency "json", "~>1.7.0"
+  s.add_dependency "json", "~>1.8.2"
 
   s.add_development_dependency "rspec", "~>2.8.0"
 


### PR DESCRIPTION
Ruby on Rails 4.2.0 requires JSON 1.8.2. I changed gemspec for compatibility with newest Rails.